### PR TITLE
New Option: Display an alert before the slave disconnects

### DIFF
--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -30,6 +30,7 @@ configspec = StringIO("""
 
 [ui]
 	play_sounds = boolean(default=True)
+	alert_before_slave_disconnect = boolean(default=True)
 	allow_speech_commands = boolean(default=True)
 	portcheck = string(default="https://nvda.es/portcheck.php?port={port}")
 """)

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -270,6 +270,9 @@ class OptionsDialog(SettingsPanel):
 		# Translators: A checkbox in add-on options dialog to set whether sounds play instead of beeps.
 		self.play_sounds = wx.CheckBox(self, wx.ID_ANY, label=_("Play sounds instead of beeps"))
 		sizer.Add(self.play_sounds)
+		# Translators: A checkbox in add-on options dialog to set whether to display an alert before the slave disconnects.
+		self.alert_before_slave_disconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Display an alert before the slave disconnects"))
+		sizer.Add(self.alert_before_slave_disconnect)
 		# Translators: A checkbox in add-on options dialog to set whether allow or block speech commands
 		self.speech_commands = wx.CheckBox(self, wx.ID_ANY, label=_("Process speech commands when controlling another computer"))
 		sizer.Add(self.speech_commands)
@@ -312,6 +315,7 @@ class OptionsDialog(SettingsPanel):
 		self.key.SetValue(cs['key'])
 		self.set_controls()
 		self.play_sounds.SetValue(config['ui']['play_sounds'])
+		self.alert_before_slave_disconnect.SetValue(config['ui']['alert_before_slave_disconnect'])
 		self.speech_commands.SetValue(config['ui']['allow_speech_commands'])
 		self.portcheck.SetValue(config['ui']['portcheck'])
 		self.originalProfileName = NVDAConfig.conf.profiles[-1].name
@@ -359,6 +363,7 @@ class OptionsDialog(SettingsPanel):
 			cs['UPNP'] = bool(self.useUPNP.GetValue())
 		cs['key'] = self.key.GetValue()
 		config['ui']['play_sounds'] = self.play_sounds.GetValue()
+		config['ui']['alert_before_slave_disconnect'] = self.alert_before_slave_disconnect.GetValue()
 		config['ui']['allow_speech_commands'] = self.speech_commands.GetValue()
 		config['ui']['portcheck'] = self.portcheck.GetValue()
 		config.write()


### PR DESCRIPTION
## Summary of the issue:

I encountered this issue at https://github.com/NVDARemote/NVDARemote/issues/185, and it has been bothering me.

When I use NVDA to control a machine thousands of miles away, it would be disastrous if I accidentally disconnected the slave machine.

## Description of Development Approach
1. **User Interface Integration**: The user interface for configuring the new option has been implemented within the `dialogs.py` module.
2. **Default Values in Configuration**: Default values for the option have been established within the `configuration.py` module, ensuring consistency with other configuration settings.
3. I implemented this feature in the `on_disconnect_item` function in `__init__.py`.
4. **Asynchronous Execution**: The function `disconnect_as_slave_with_alert` utilizes the `wx.CallAfter` method to ensure asynchronous execution in the UI thread, preventing potential blocking during the disconnect process.
5. I fine-tuned the `script disconnect` function and called `on_disconnect_item` to cover scenarios where the user uses gestures to disconnect.

## Testing Strategy:
1. With "Display an alert before the slave disconnects" checked, try disconnecting from the remote menu.
2. With "Display an alert before the slave disconnects" checked, attempt to disconnect using gestures.
3. With "Display an alert before the slave disconnects" unchecked, repeat the above two disconnection methods.
4. Perform the same tests on the master machine.
