### PR TITLE
Handling dialog boxes that allow users to open them repeatedly

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -423,6 +423,11 @@ class GlobalPlugin(_GlobalPlugin):
 	def do_connect(self, evt):
 		if evt:
 			evt.Skip()
+		# Check if the connect dialog is already open
+		if getattr(self, 'is_connect_dialog_open', False):
+			return
+		# Set the flag to True, indicating that the connect dialog is open
+		setattr(self, 'is_connect_dialog_open', True)
 		last_cons = configuration.get_config()['connections']['last_connected']
 		# Translators: Title of the connect dialog.
 		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"))
@@ -430,6 +435,8 @@ class GlobalPlugin(_GlobalPlugin):
 		dlg.panel.host.SetSelection(0)
 		def handle_dlg_complete(dlg_result):
 			if dlg_result != wx.ID_OK:
+				# Reset the flag to False when the dialog is closed
+				setattr(self, 'is_connect_dialog_open', False)
 				return
 			if dlg.client_or_server.GetSelection() == 0: #client
 				host = dlg.panel.host.GetValue()
@@ -446,6 +453,8 @@ class GlobalPlugin(_GlobalPlugin):
 					self.connect_as_master(('127.0.0.1', int(dlg.panel.port.GetValue())), channel, insecure=True)
 				else:
 					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel, insecure=True)
+			# Reset the flag to False when the dialog is closed
+			setattr(self, 'is_connect_dialog_open', False)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
 
 	def on_connected_as_master(self):

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -229,22 +229,21 @@ class GlobalPlugin(_GlobalPlugin):
 		def disconnect_as_slave_with_alert():
 			if (self.slave_transport is not None
 				and configuration.get_config()['ui']['alert_before_slave_disconnect']
-				and gui.messageBox(
+				and not gui.message.isModalMessageBoxActive()):  # Check if a modal message box is open
+				result = gui.messageBox(
 					# Translators: question before disconnecting
 					message=_("Are you sure you want to disconnect the slave?"),
 					# Translators: question title
 					caption=_("Warning!"),
 					style=wx.YES | wx.NO | wx.ICON_WARNING
-				) == wx.YES
-			):
+				)
+				if result == wx.YES:
+					self.disconnect()
+			elif (self.master_transport is not None
+				  or (self.slave_transport is not None
+					  and not configuration.get_config()['ui']['alert_before_slave_disconnect'])):
 				self.disconnect()
 		wx.CallAfter(disconnect_as_slave_with_alert)
-		if (self.master_transport is not None
-			or (
-				self.slave_transport is not None 
-				and not configuration.get_config()['ui']['alert_before_slave_disconnect'])
-		):
-			self.disconnect()
 
 	def on_mute_item(self, evt):
 		if evt:


### PR DESCRIPTION
## Summary of the issue:
This pull request aims to enforce a single-instance restriction on dialog boxes, ensuring that users can open and interact with only one dialog box at a time. By implementing this enhancement, we improve the user experience by preventing the simultaneous opening of multiple dialog boxes, which can lead to confusion and inefficiency.

## Description of user-facing changes:
Now, the connection dialog, send file dialog, and alert dialog for disconnecting the controlled machine are all single-instanced. In the past, none of these dialogs were single-instanced,i.e. allowing users to open more than one dialog simultaneously.

## Description of development approach:
I handled `do_connect`, `on_send_file_item`, and `on_disconnect_item` respectively. I added a class property to track the open state of these dialogs. It is worth noting that I also made a small change to `on_disconnect_item`, which has made the code logic clearer.

## Testing strategy:
1. Use gestures to attempt opening the connect dialog, send file dialog, and disconnect dialog on the controlled machine.
2. Perform the same operations using the items in the remote menu.
