### PR TITLE
bug fixes for mute flag

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -473,13 +473,13 @@ class GlobalPlugin(_GlobalPlugin):
 
 	def on_connected_as_master(self):
 		configuration.write_connection_to_config(self.master_transport.address)
+		self.copy_link_remote_item.Enable(True)
+		self.copy_link_tele_item.Enable(True)
 		if not self.menu.FindItemById(self.send_ctrl_alt_del_item.Id):
 			self.menu.Insert(0, self.send_ctrl_alt_del_item)
 		if not globalVars.appArgs.secure:
 			if not self.menu.FindItemById(self.send_file_item.Id):
 				self.menu.Insert(0, self.send_file_item)
-		self.copy_link_remote_item.Enable(True)
-		self.copy_link_tele_item.Enable(True)
 		if not self.menu.FindItemById(self.push_clipboard_item.Id):
 			self.menu.Insert(0, self.push_clipboard_item)
 		if not self.menu.FindItemById(self.mute_item.Id):
@@ -557,13 +557,13 @@ class GlobalPlugin(_GlobalPlugin):
 		cues.control_server_connected()
 		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
 		speech.speakMessage(_("Connected to control server"))
+		self.copy_link_remote_item.Enable(True)
+		self.copy_link_tele_item.Enable(True)
 		if not globalVars.appArgs.secure:
 			if not self.menu.FindItemById(self.send_file_item.Id):
 				self.menu.Insert(0, self.send_file_item)
 		if not self.menu.FindItemById(self.push_clipboard_item.Id):
 			self.menu.Insert(0, self.push_clipboard_item)
-		self.copy_link_remote_item.Enable(True)
-		self.copy_link_tele_item.Enable(True)
 		if not self.menu.FindItemById(self.disconnect_item.Id):
 			self.menu.Insert(0, self.disconnect_item)
 		if self.menu.FindItemById(self.connect_item.Id):

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -260,9 +260,11 @@ class GlobalPlugin(_GlobalPlugin):
 		if self.local_machine.is_muted:
 			# Translators: Menu item in TeleNVDA submenu to unmute speech and sounds from the remote computer.
 			self.mute_item.SetItemLabel(_("Unmute remote"))
+			ui.message(_("Mute speech and sounds from the remote computer"))
 		else:
 			# Translators: Menu item in TeleNVDA submenu to mute speech and sounds from the remote computer.
 			self.mute_item.SetItemLabel(_("Mute remote"))
+			ui.message(_("Unmute speech and sounds from the remote computer"))
 
 	def on_push_clipboard_item(self, evt):
 		connector = self.slave_transport or self.master_transport
@@ -821,4 +823,3 @@ class GlobalPlugin(_GlobalPlugin):
 		self.on_mute_item(None)
 		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
 		status = _("Mute speech and sounds from the remote computer") if self.local_machine.is_muted else _("Unmute speech and sounds from the remote computer")
-		ui.message(status)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -408,10 +408,10 @@ class GlobalPlugin(_GlobalPlugin):
 				self.menu.Remove(self.push_clipboard_item.Id)
 			if self.menu.FindItemById(self.send_file_item.Id):
 				self.menu.Remove(self.send_file_item.Id)
-			self.copy_link_remote_item.Enable(False)
-			self.copy_link_tele_item.Enable(False)
 			if self.menu.FindItemById(self.send_ctrl_alt_del_item.Id):
 				self.menu.Remove(self.send_ctrl_alt_del_item.Id)
+			self.copy_link_remote_item.Enable(False)
+			self.copy_link_tele_item.Enable(False)
 		if self.local_machine:
 			self.local_machine.is_muted = False
 		self.sending_keys = False

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -819,7 +819,7 @@ class GlobalPlugin(_GlobalPlugin):
 		# Translators: gesture description for the toggle remote mute script
 		_("""Mute or unmute the speech coming from the remote computer"""))
 	def script_toggle_remote_mute(self, gesture):
-		if not self.is_connected() or self.connecting: return
+		if not self.is_connected() or self.connecting or self.slave_transport: return
 		self.on_mute_item(None)
 		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
 		status = _("Mute speech and sounds from the remote computer") if self.local_machine.is_muted else _("Unmute speech and sounds from the remote computer")


### PR DESCRIPTION
speach is now announced when muting or unmuting by the option as whel
mute shortcut key is no longer enable when connected as slave
note: for making the speach to be announced when using the option as whel, i've removed the speach from the shortcut key function because that was causing a bug that using the shortcut would speeck the announcement 2 times. Now, it is only announced once, and it is announced for the shortcut, and for the option as whelll.