### PR TITLE
bug fixes for the mute flag

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -809,5 +809,3 @@ class GlobalPlugin(_GlobalPlugin):
 	def script_toggle_remote_mute(self, gesture):
 		if not self.is_connected() or self.connecting or self.slave_transport: return
 		self.on_mute_item(None)
-		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
-		status = _("Mute speech and sounds from the remote computer") if self.local_machine.is_muted else _("Unmute speech and sounds from the remote computer")

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -260,9 +260,11 @@ class GlobalPlugin(_GlobalPlugin):
 		if self.local_machine.is_muted:
 			# Translators: Menu item in TeleNVDA submenu to unmute speech and sounds from the remote computer.
 			self.mute_item.SetItemLabel(_("Unmute remote"))
+			ui.message(_("Mute speech and sounds from the remote computer"))
 		else:
 			# Translators: Menu item in TeleNVDA submenu to mute speech and sounds from the remote computer.
 			self.mute_item.SetItemLabel(_("Mute remote"))
+			ui.message(_("Unmute speech and sounds from the remote computer"))
 
 	def on_push_clipboard_item(self, evt):
 		connector = self.slave_transport or self.master_transport
@@ -805,8 +807,7 @@ class GlobalPlugin(_GlobalPlugin):
 		# Translators: gesture description for the toggle remote mute script
 		_("""Mute or unmute the speech coming from the remote computer"""))
 	def script_toggle_remote_mute(self, gesture):
-		if not self.is_connected() or self.connecting: return
+		if not self.is_connected() or self.connecting or self.slave_transport: return
 		self.on_mute_item(None)
 		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
 		status = _("Mute speech and sounds from the remote computer") if self.local_machine.is_muted else _("Unmute speech and sounds from the remote computer")
-		ui.message(status)


### PR DESCRIPTION
the (Mute speach and sounds from the remote computer) and (Unmute speach and sounds from the remote computer) speach is now announced when using the option as whell. Note that i removed the announcement from the gesture function because it was making the announcement speack 2 times when using the gesture, but now it only announces once with both option, and gesture, works perfectly fine.
when connected as slave, the mute gesture is no longer enabled, so that it will no longer toggle the mute option even though it is unavailable in that case so you can't toggle it using the option