### PR TITLE
added an unassighned gesture for the send ctrl+alt+del option

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -366,6 +366,8 @@ class GlobalPlugin(_GlobalPlugin):
 
 	def on_send_ctrl_alt_del(self, evt):
 		self.master_transport.send('send_SAS')
+		# Translators: message spoken when the Ctrl+Alt+Delete has been sent to the remote machine successfully
+		ui.message(_("Ctrl+Alt+Delete has been sent to the remote machine"))
 
 	def disconnect(self):
 		if self.master_transport is None and self.slave_transport is None:
@@ -809,3 +811,10 @@ class GlobalPlugin(_GlobalPlugin):
 	def script_toggle_remote_mute(self, gesture):
 		if not self.is_connected() or self.connecting or self.slave_transport: return
 		self.on_mute_item(None)
+
+	@script(
+		# Translators: send Ctrl+Alt+Delete gesture description
+		_("""Sends the Ctrl+Alt+Delete to the remote machine"""))
+	def script_send_ctrl_alt_del(self, gesture):
+		if not self.is_connected() or self.connecting or self.slave_transport: return
+		self.on_send_ctrl_alt_del(None)

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ Welcome to the TeleNVDA addon, which will allow you to connect to another comput
 * An option allows blocking remote speech commands different from text.
 * Improved support for proxy servers and TOR hidden services ([Proxy support add-on](https://addons.nvda-project.org/addons/proxy.en.html) is required).
 * Ability to change the f11 key to another gesture. Now this works as a common script so, you can assign gestures in the "Input Gestures" dialog.
+* Ability to assign a gesture to the send ctrl+alt+delete option in the input Gestures dialog. Warning! you shouldn't assighn the ctrl+alt+delete keys to this option. Doing it  will stil work normally, but anytime you press ctrl+alt+delete keys to send the ctrl+alt+delete to the remote machine, your own machine will also be effected by the ctrl+alt+delete function, which is likely not what you expect!
 * Ability to ignore the next immediate gesture completely, it is useful if you need to send to the remote machine the gesture used to toggle between host and remote machine.
 * Ability to exchange small files (up to 10 MB) among users connected to the same session.
 * Ability to forward ports via UPNP.
@@ -104,7 +105,7 @@ Note that the shared link may not work if you copy it from a server running in d
 
 While sending keys, it is not possible to send the CTRL+Alt+del combination normally.
 
-If you need to send CTRL+Alt+del, and the remote system is on the secure desktop, use this command.
+If you need to send CTRL+Alt+del, and the remote system is on the secure desktop, use this command. You can also assighn a gesture for this command in the input Gestures dialog.
 
 ## Send toggle key between local and remote computer
 


### PR DESCRIPTION
i updated the documentation and tested everything works properly
assighned a gesture to the option and tested that it works as expected and with out any problem, also added a speech announce for the option so you'll know that it is done when you press it, like as other options, also, the discription for the catigory in the Input Gestures  dialog is also fine
and inclooded a translator comment for everything i've added that was needed translation
and the last, i've mentioned about this ability in the documentation readme.md under current difrences section as whel as under sending ctrl+alt+del section