### PR TITLE
added an option to mute remote speech when controlling local machine

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -485,6 +485,8 @@ class GlobalPlugin(_GlobalPlugin):
 		self.copy_link_remote_item.Enable(True)
 		self.copy_link_tele_item.Enable(True)
 		self.send_ctrl_alt_del_item.Enable(True)
+		if configuration.get_config()['ui']['mute_when_controlling_local_machine'] and not self.local_machine.is_muted:
+			self.on_mute_item(None)
 		# We might have already created a hook thread before if we're restoring an
 		# interrupted connection. We must not create another.
 		if not self.hook_thread:
@@ -801,6 +803,8 @@ class GlobalPlugin(_GlobalPlugin):
 			return
 		self.sending_keys = not self.sending_keys
 		self.set_receiving_braille(self.sending_keys)
+		if configuration.get_config()['ui']['mute_when_controlling_local_machine'] and self.local_machine.is_muted:
+			self.on_mute_item(None)
 		if self.sending_keys:
 			self.hostPendingModifiers = gesture.modifiers
 			# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
@@ -810,6 +814,8 @@ class GlobalPlugin(_GlobalPlugin):
 			for k in self.key_modifiers:
 				self.master_transport.send(type="key", vk_code=k[0], extended=k[1], pressed=False)
 			self.key_modifiers = set()
+			if configuration.get_config()['ui']['mute_when_controlling_local_machine'] and not self.local_machine.is_muted:
+				self.on_mute_item(None)
 			# Translators: Presented when keyboard control is back to the controlling computer.
 			ui.message(_("Controlling local machine."))
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -485,8 +485,6 @@ class GlobalPlugin(_GlobalPlugin):
 		self.copy_link_remote_item.Enable(True)
 		self.copy_link_tele_item.Enable(True)
 		self.send_ctrl_alt_del_item.Enable(True)
-		if configuration.get_config()['ui']['mute_when_controlling_local_machine'] and not self.local_machine.is_muted:
-			self.on_mute_item(None)
 		# We might have already created a hook thread before if we're restoring an
 		# interrupted connection. We must not create another.
 		if not self.hook_thread:

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -31,6 +31,7 @@ configspec = StringIO("""
 [ui]
 	play_sounds = boolean(default=True)
 	alert_before_slave_disconnect = boolean(default=True)
+	mute_when_controlling_local_machine = boolean(default=False)
 	allow_speech_commands = boolean(default=True)
 	portcheck = string(default="https://nvda.es/portcheck.php?port={port}")
 """)

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -273,6 +273,9 @@ class OptionsDialog(SettingsPanel):
 		# Translators: A checkbox in add-on options dialog to set whether to display an alert before the controlled computer disconnects.
 		self.alert_before_slave_disconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Display an alert before the controlled computer disconnects"))
 		sizer.Add(self.alert_before_slave_disconnect)
+		# Translators: A checkbox in add-on options dialog to set whether to mute remote speech when controlling the local machine.
+		self.mute_when_controlling_local_machine = wx.CheckBox(self, wx.ID_ANY, label=_("Mute remote speech when controlling local machine"))
+		sizer.Add(self.mute_when_controlling_local_machine)
 		# Translators: A checkbox in add-on options dialog to set whether allow or block speech commands
 		self.speech_commands = wx.CheckBox(self, wx.ID_ANY, label=_("Process speech commands when controlling another computer"))
 		sizer.Add(self.speech_commands)
@@ -316,6 +319,7 @@ class OptionsDialog(SettingsPanel):
 		self.set_controls()
 		self.play_sounds.SetValue(config['ui']['play_sounds'])
 		self.alert_before_slave_disconnect.SetValue(config['ui']['alert_before_slave_disconnect'])
+		self.mute_when_controlling_local_machine.SetValue(config['ui']['mute_when_controlling_local_machine'])
 		self.speech_commands.SetValue(config['ui']['allow_speech_commands'])
 		self.portcheck.SetValue(config['ui']['portcheck'])
 		self.originalProfileName = NVDAConfig.conf.profiles[-1].name
@@ -364,6 +368,7 @@ class OptionsDialog(SettingsPanel):
 		cs['key'] = self.key.GetValue()
 		config['ui']['play_sounds'] = self.play_sounds.GetValue()
 		config['ui']['alert_before_slave_disconnect'] = self.alert_before_slave_disconnect.GetValue()
+		config['ui']['mute_when_controlling_local_machine'] = self.mute_when_controlling_local_machine.GetValue()
 		config['ui']['allow_speech_commands'] = self.speech_commands.GetValue()
 		config['ui']['portcheck'] = self.portcheck.GetValue()
 		config.write()

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Note: in order to make download easier for users who need assistance or training
 Welcome to the TeleNVDA addon, which will allow you to connect to another computer running the free NVDA screen reader. With this add-on, you can connect to another person's computer, or allow a trusted person to connect to your system to perform routine maintenance, diagnose a problem, or provide training. This add-on is a modified version of the [NVDA Remote add-on](https://nvdaremote.com), and is maintained by the NVDA spanish community. It's fully compatible with NVDA Remote. These are the current differences:
 
 * An option allows blocking remote speech commands different from text.
+* An option to mute remote speech when controlling the local machine and unmute it when controlling the remote machine.
 * Improved support for proxy servers and TOR hidden services ([Proxy support add-on](https://addons.nvda-project.org/addons/proxy.en.html) is required).
 * Ability to change the f11 key to another gesture. Now this works as a common script so, you can assign gestures in the "Input Gestures" dialog.
 * a gesture (unassigned by default) to open the addon options


### PR DESCRIPTION
… Tested all of the possible cases and made sure there's no bug. Added comments for translators. Updated documentation.
@jmdaweb i did everything you asked me to do. You wanted it this way, and i developed it as follows. When this option is checked, controlling remote computer unmutes the remote, and controlling the local computer mutes it, as expected, and also, the controler can mute or unmute explisitly, by pressing option or the shortcut, for example, you can controle local computer and unmute it and here the remote stil. There's no problem, but i wanted to ask a simple thing. now, up on swiching between local and remote computers, the muted and unmuted speech is also announced, i didn't removed it because i thort it is useful and people who have this option checked, will know what's happening, but if you don't want it, i can disable it. i'm waiting for your comments, and i hope i was useful for this project.